### PR TITLE
Fixed block declaration warning on Marketo.h

### DIFF
--- a/Marketo.framework/Headers/Marketo.h
+++ b/Marketo.framework/Headers/Marketo.h
@@ -117,7 +117,7 @@
  */
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
 didReceiveNotificationResponse:(UNNotificationResponse *)response
-         withCompletionHandler:(void(^)())completionHandler;
+         withCompletionHandler:(void(^)(void))completionHandler;
 /*!
  * Set security Signature for Authentication
  * @param token - The Security Token recived from client server


### PR DESCRIPTION
Xcode 9 throws a warning on `Marketo.h` that "The block declaration is not a prototype".

In full: 
`/ios-sdk/Marketo.framework/Headers/Marketo.h:120:40: This block declaration is not a prototype`

Explicitly setting the parameter list to void/no parameters as suggested in the "[Working with Blocks](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/WorkingwithBlocks/WorkingwithBlocks.html)" guide fixes the warning!